### PR TITLE
Delete messages in bulk after upload succeeded

### DIFF
--- a/sqs_s3_logger/lambda_function.py
+++ b/sqs_s3_logger/lambda_function.py
@@ -26,8 +26,25 @@ def handler(event, context):
     s3.meta.client.head_bucket(Bucket=b_name)  # Check that the bucket exists.
     b = s3.Bucket(b_name)
     msgs = read_queue(q)
-    dump_messages_to_file(msgs, temp_filepath)
+    written = dump_messages_to_file(msgs, temp_filepath)
     b.upload_file(temp_filepath, '{}.txt'.format(datetime.datetime.now()))
+
+    failed_deletions = batch_delete_messages(q, written)
+    if failed_deletions:
+        LOGGER.info('Deletion of {} messages failed'.format(len(failed_deletions)))
+
+
+def batch_delete_messages(queue, messages):
+    deletion_results = []
+    for i in range(0, len(messages), 10):
+        deletion_result = queue.delete_messages(
+            Entries=[
+                {'Id': m.message_id, 'ReceiptHandle': m.receipt_handle}
+                for m in messages[i : i + 10]
+            ]
+        )
+        deletion_results += deletion_result.get('Failed', [])
+    return deletion_results
 
 
 def read_queue(queue):
@@ -36,13 +53,14 @@ def read_queue(queue):
     while len(messages) > 0:
         for message in messages:
             yield message
-            # TODO instead of deleting those, keep the handles, remove in batch once they're on S3
-            message.delete()
         messages = queue.receive_messages(
             MaxNumberOfMessages=10, WaitTimeSeconds=1)
 
 
-def dump_messages_to_file(msgs, file):
-    with open(file, 'w') as f:
+def dump_messages_to_file(msgs, file_name):
+    written_messages = []
+    with open(file_name, 'w') as f:
         for message in msgs:
             f.write(message.body + '\n')
+            written_messages.append(message)
+    return written_messages


### PR DESCRIPTION
Right now messages are deleted immediately after they have been read, which might lead to loss of messages in case of S3 problems (bad configuration).

This PR picks up the TODO in the code and deletes the messages in batch after the upload to S3 has succeeded.